### PR TITLE
prevent updates after animation end

### DIFF
--- a/src/odoo.js
+++ b/src/odoo.js
@@ -136,7 +136,8 @@ export default ({
         const filterOrigin = targetDistance / 2;
         const motionValue = Math.abs(Math.abs(value - filterOrigin) - filterOrigin) / 100;
         select(`#motionFilter-${digit.id} .blurValues`)::attr('stdDeviation', `0 ${motionValue}`);
-      }
+      },
+      end: i === 0 ? () => cancelAnimation() : (e) => e
     });
     transitions.push(digitTransition);
   });
@@ -157,5 +158,6 @@ export default ({
     transitions.forEach(transition => transition.update(timestamp));
   };
 
-  return loop(update);
+  const cancelAnimation = loop(update);
+  return cancelAnimation;
 };


### PR DESCRIPTION
I think we should stop updates after animation end. It will prevent forced reflows. See timeline capture for additional info:
![image](https://cloud.githubusercontent.com/assets/2841858/18137769/7b70b590-6fb2-11e6-938a-986fe9117bbc.png)
